### PR TITLE
Fix typo in utils and ensure newline

### DIFF
--- a/utils.c
+++ b/utils.c
@@ -44,7 +44,7 @@ void waitNoButtonPressed()
 {
     while(1)
     {
-        // wait 10 mili-seconds
+        // wait 10 milliseconds
         tslp_tsk(10);
         
         int stop = 1;


### PR DESCRIPTION
## Summary
- fix misspelling of `milliseconds` in `utils.c`
- ensure `utils.c` ends with a newline

## Testing
- `make`
- `make -f Makefile.inc`


------
https://chatgpt.com/codex/tasks/task_e_6861bae61aec832d88b678da29475485