### PR TITLE
Update interval time comment

### DIFF
--- a/app.c
+++ b/app.c
@@ -138,8 +138,7 @@ static ER calibrate_gyro_sensor() {
 static void update_interval_time() {
     static SYSTIM start_time;
 
-    if(loop_count++ == 0) { // Interval time for the first time (use 6ms as a magic number)
-        //interval_time = 0.006;
+    if(loop_count++ == 0) { // Interval time for the first iteration (use INIT_INTERVAL_TIME)
         interval_time = INIT_INTERVAL_TIME;
         ER ercd = get_tim(&start_time);
         assert(ercd == E_OK);


### PR DESCRIPTION
## Summary
- reference `INIT_INTERVAL_TIME` for the first loop interval comment in `app.c`
- remove leftover commented code

## Testing
- `make -n` *(fails: no makefile)*

------
https://chatgpt.com/codex/tasks/task_e_6861bb1aedf0832dbb235e7574272044