### PR TITLE
Add restart after fall

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ The balancing logic in `app.c` uses gyro and motor feedback. Parameters like `KG
 
 `ev3eyes.c` expects BMP images in `/eyes_imgs` on the EV3 filesystem. The functions load these bitmaps and draw them on the LCD, allowing simple facial expressions while the robot is running.
 
+## Recovering from Falls
+
+If the robot tips over, `balance_task` stops and the status becomes `KNOCK_OUT_STATUS`.
+Press the center (Enter) button to restart the balancing task. The program will
+recalibrate the gyro sensor and resume operation once the status changes to
+`RUNNING_STATUS`.
+
 ## Getting Started
 
 To build and run the program, install the EV3RT toolchain and follow its standard workflow for compiling and deploying applications to the EV3. The code relies on `ev3api.h` from EV3RT.

--- a/app.c
+++ b/app.c
@@ -324,6 +324,14 @@ static void button_clicked_handler(intptr_t button) {
         break;
     case LEFT_BUTTON:
         syslog(LOG_NOTICE, "Left button clicked.");
+        break;
+    case ENTER_BUTTON:
+        syslog(LOG_NOTICE, "Enter button clicked.");
+        if (gyrohunter_status == KNOCK_OUT_STATUS) {
+            syslog(LOG_NOTICE, "Restarting balance task.");
+            act_tsk(BALANCE_TASK);
+        }
+        break;
     }
 }
 
@@ -527,6 +535,13 @@ void main_task(intptr_t unused) {
         if (gyrohunter_status == KNOCK_OUT_STATUS)
         {
             DRAW_EYES(EV3EYE_DIZZY);
+            if (ev3_button_is_pressed(ENTER_BUTTON)) {
+                waitButtonRelease(ENTER_BUTTON);
+                act_tsk(BALANCE_TASK);
+                while (gyrohunter_status != RUNNING_STATUS) {
+                    tslp_tsk(50);
+                }
+            }
             tslp_tsk(1000);
             continue;
         }


### PR DESCRIPTION
## Summary
- trigger restarting `balance_task` when the robot has fallen
- add button logic and instructions for recovery

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6861cd9ae9a0832da7d0231d199fb513